### PR TITLE
Fix submission alarm accuracy

### DIFF
--- a/app/src/main/java/org/coscup/ccip/util/AlarmUtil.java
+++ b/app/src/main/java/org/coscup/ccip/util/AlarmUtil.java
@@ -4,13 +4,17 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+
 import com.google.gson.internal.bind.util.ISO8601Utils;
+
+import org.coscup.ccip.activity.SubmissionDetailActivity;
+import org.coscup.ccip.model.Submission;
+
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.Calendar;
 import java.util.Date;
-import org.coscup.ccip.activity.SubmissionDetailActivity;
-import org.coscup.ccip.model.Submission;
 
 public class AlarmUtil {
 
@@ -27,7 +31,11 @@ public class AlarmUtil {
                     .getBroadcast(context, submission.hashCode(), intent, 0);
 
             AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-            alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - 10 * 60 * 1000, pendingIntent);
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - 10 * 60 * 1000, pendingIntent);
+            else {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - 10 * 60 * 1000, pendingIntent);
+            }
         } catch (ParseException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
https://developer.android.com/about/versions/android-4.4#BehaviorAlarms
Android 4.4 開始不保證 `set` 方法準確，要改用 `setExact`

https://developer.android.com/training/monitoring-device-state/doze-standby
Android 6.0 Doze 模式會受影響，必須使用 `setExactAndAllowWhileIdle` 避免。