### PR TITLE
Drawer improvements

### DIFF
--- a/app/src/main/java/app/opass/ccip/activity/MainActivity.kt
+++ b/app/src/main/java/app/opass/ccip/activity/MainActivity.kt
@@ -26,6 +26,8 @@ import com.google.android.material.navigation.NavigationView
 import com.google.zxing.integration.android.IntentIntegrator
 import com.squareup.picasso.Picasso
 
+private const val STATE_SELECTED_MENU_ITEM_ID = "selectedMenuItemId"
+
 class MainActivity : AppCompatActivity() {
     companion object {
         private val URI_GITHUB = Uri.parse("https://github.com/CCIP-App/CCIP-Android")
@@ -58,9 +60,11 @@ class MainActivity : AppCompatActivity() {
 
         drawerToggle = ActionBarDrawerToggle(this, mDrawerLayout, toolbar, R.string.drawer_open, R.string.drawer_close)
 
-        setTitle(R.string.fast_pass)
-        supportFragmentManager.transaction {
-            replace(R.id.content_frame, MainFragment())
+        val item = savedInstanceState?.getInt(STATE_SELECTED_MENU_ITEM_ID)?.let(navigationView.menu::findItem)
+        if (item != null) {
+            jumpToFragment(item)
+        } else {
+            jumpToFragment(navigationView.menu.findItem(R.id.fast_pass))
         }
 
         updateConfLogo()
@@ -100,6 +104,11 @@ class MainActivity : AppCompatActivity() {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         drawerToggle.onConfigurationChanged(newConfig)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        navigationView.checkedItem?.let { item -> outState.putInt(STATE_SELECTED_MENU_ITEM_ID, item.itemId) }
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/app/opass/ccip/activity/MainActivity.kt
+++ b/app/src/main/java/app/opass/ccip/activity/MainActivity.kt
@@ -144,7 +144,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun jumpToFragment(menuItem: MenuItem): Boolean {
-        menuItem.isChecked = true
+        if (menuItem.isCheckable) menuItem.isChecked = true
 
         when {
             menuItem.itemId == R.id.star -> mActivity.startActivity(Intent(Intent.ACTION_VIEW, URI_GITHUB))

--- a/app/src/main/java/app/opass/ccip/activity/MainActivity.kt
+++ b/app/src/main/java/app/opass/ccip/activity/MainActivity.kt
@@ -112,14 +112,16 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        if (navigationView.menu.findItem(R.id.fast_pass).isChecked) {
-            super.onBackPressed()
-        } else {
-            setTitle(R.string.fast_pass)
-            supportFragmentManager.transaction {
-                replace(R.id.content_frame, MainFragment())
+        when {
+            mDrawerLayout.isDrawerOpen(GravityCompat.START) -> mDrawerLayout.closeDrawers()
+            navigationView.menu.findItem(R.id.fast_pass).isChecked -> super.onBackPressed()
+            else -> {
+                setTitle(R.string.fast_pass)
+                supportFragmentManager.transaction {
+                    replace(R.id.content_frame, MainFragment())
+                }
+                navigationView.setCheckedItem(R.id.fast_pass)
             }
-            navigationView.setCheckedItem(R.id.fast_pass)
         }
     }
 

--- a/app/src/main/res/menu/drawer.xml
+++ b/app/src/main/res/menu/drawer.xml
@@ -25,7 +25,8 @@
         <item
             android:id="@+id/telegram"
             android:icon="@drawable/telegram_logo"
-			android:title="@string/telegram" />
+            android:checkable="false"
+            android:title="@string/telegram" />
         <item
             android:id="@+id/irc"
             android:icon="@drawable/ic_question_answer_black_48dp"
@@ -45,6 +46,7 @@
         <item
             android:id="@+id/star"
             android:icon="@drawable/github_mark"
+            android:checkable="false"
             android:title="@string/star_on_github" />
     </group>
 </menu>


### PR DESCRIPTION
- 會開瀏覽器的選單項目現在不會呈現為已選擇的狀態了

在之前，如果我在快速通關頁面點 Telegram 或 GitHub 的話，選單項目會變成已選擇的狀態，點返回的時候就會因為 app 覺得我不是在快速通關頁面，要多按一次返回（而且還會跟我還原 fragment 的機制打架）
- 現在 drawer 可以透過返回鍵收起了
- 在系統殺掉 app 後再度開啟時跳至先前選擇的 fragment