### PR TITLE
Ignore intent when launched from Recents

### DIFF
--- a/app/src/main/java/app/opass/ccip/activity/MainActivity.kt
+++ b/app/src/main/java/app/opass/ccip/activity/MainActivity.kt
@@ -62,9 +62,11 @@ class MainActivity : AppCompatActivity() {
         drawerToggle = ActionBarDrawerToggle(this, mDrawerLayout, toolbar, R.string.drawer_open, R.string.drawer_close)
 
         val savedItem = savedInstanceState?.getInt(STATE_SELECTED_MENU_ITEM_ID)?.let(navigationView.menu::findItem)
+        val isFromNotification = intent.getBooleanExtra(ARG_IS_FROM_NOTIFICATION, false)
+        val isLaunchedFromHistory = intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY == Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
         val item = when {
             savedItem != null -> savedItem
-            intent.getBooleanExtra(ARG_IS_FROM_NOTIFICATION, false) -> navigationView.menu.findItem(R.id.announcement)
+            isFromNotification and !isLaunchedFromHistory -> navigationView.menu.findItem(R.id.announcement)
             else -> navigationView.menu.findItem(R.id.fast_pass)
         }
         jumpToFragment(item)


### PR DESCRIPTION
問題重現方法：
1 .從 Recents 滑掉 app
2. 透過點選通知啟動 app
3. 透過返回鍵關閉 app
4. 從 Recents 開啟 app

預期結果：
App 開啟並且在快速通關頁面

實際狀況：
App 開啟並且在公告頁面