### PR TITLE
Upgrade sdk versions & Fix Manifest

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,12 +17,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdk 32
 
     defaultConfig {
         applicationId "app.opass.ccip"
-        minSdkVersion 24
-        targetSdkVersion 30
+        minSdk 24
+        targetSdk 32
         versionCode 44
         versionName "3.2.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
             android:name="com.onesignal.NotificationOpened.DEFAULT"
             android:value="DISABLE" />
 
-        <activity android:name=".ui.LauncherActivity">
+        <activity android:name=".ui.LauncherActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -57,7 +57,7 @@
             android:screenOrientation="portrait" />
 
         <receiver android:name=".util.SessionAlarmReceiver" />
-        <receiver android:name=".util.RebootReceiver">
+        <receiver android:name=".util.RebootReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>


### PR DESCRIPTION
Version Upgrade for SDK and Fix AndroidManifest
1. Upgrade compileSdk and targetSdk
2. Auto change Keywords for compileSdk, minSdk, targetSdk from androidStudio
3. Add android:export=True in `.ui.LauncherActivity` and `.util.RebootReceiver` 