### PR TITLE
Rework alarm permission logic

### DIFF
--- a/app/src/main/java/app/opass/ccip/ui/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/app/opass/ccip/ui/schedule/ScheduleFragment.kt
@@ -1,12 +1,18 @@
 package app.opass.ccip.ui.schedule
 
 import android.app.Activity
+import android.app.AlarmManager
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -25,6 +31,12 @@ import app.opass.ccip.util.AlarmUtil
 import app.opass.ccip.util.PreferenceUtil
 
 class ScheduleFragment : Fragment() {
+
+    private val startForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ ->
+            context?.let { AlarmUtil.setSessionAlarm(it, session) }
+        }
+
     companion object {
         private const val ARG_DATE = "ARG_DATE"
 
@@ -42,6 +54,7 @@ class ScheduleFragment : Fragment() {
     private lateinit var mActivity: Activity
     private lateinit var vm: ScheduleViewModel
     private lateinit var scheduleView: RecyclerView
+    private lateinit var session: Session
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -103,14 +116,24 @@ class ScheduleFragment : Fragment() {
     }
 
     private fun onToggleStarState(session: Session): Boolean {
+        this.session = session
         val sessionIds = PreferenceUtil.loadStarredIds(mActivity).toMutableList()
         val isAlreadyStarred = sessionIds.contains(session.id)
         if (isAlreadyStarred) {
             sessionIds.remove(session.id)
             AlarmUtil.cancelSessionAlarm(mActivity, session)
         } else {
-            sessionIds.add(session.id)
-            AlarmUtil.setSessionAlarm(mActivity, session)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val alarmManager = context?.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                if (alarmManager.canScheduleExactAlarms()) {
+                    AlarmUtil.setSessionAlarm(mActivity, session)
+                } else {
+                    val uri = Uri.parse("package:" + requireContext().packageName)
+                    startForResult.launch(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, uri))
+                }
+            } else {
+                AlarmUtil.setSessionAlarm(mActivity, session)
+            }
         }
         vm.hasStarredSessions.value = sessionIds.isNotEmpty()
         PreferenceUtil.saveStarredIds(mActivity, sessionIds)

--- a/app/src/main/java/app/opass/ccip/ui/sessiondetail/SessionDetailActivity.kt
+++ b/app/src/main/java/app/opass/ccip/ui/sessiondetail/SessionDetailActivity.kt
@@ -1,6 +1,7 @@
 package app.opass.ccip.ui.sessiondetail
 
 import android.app.Activity
+import android.app.AlarmManager
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -8,12 +9,15 @@ import android.content.Intent
 import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
@@ -34,6 +38,12 @@ import java.text.ParsePosition
 import java.text.SimpleDateFormat
 
 class SessionDetailActivity : AppCompatActivity() {
+
+    private val startForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ ->
+            AlarmUtil.setSessionAlarm(this, session)
+        }
+
     companion object {
         const val INTENT_EXTRA_SESSION_ID = "session_id"
         private val SDF_DATETIME = SimpleDateFormat("MM/dd HH:mm")
@@ -202,9 +212,19 @@ class SessionDetailActivity : AppCompatActivity() {
             AlarmUtil.cancelSessionAlarm(this, session)
             Snackbar.make(view, R.string.remove_bookmark, Snackbar.LENGTH_LONG).show()
         } else {
-            sessionIds.add(session.id)
-            AlarmUtil.setSessionAlarm(this, session)
-            Snackbar.make(view, R.string.add_bookmark, Snackbar.LENGTH_LONG).show()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val alarmManager = this.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                if (alarmManager.canScheduleExactAlarms()) {
+                    AlarmUtil.setSessionAlarm(mActivity, session)
+                    Snackbar.make(view, R.string.add_bookmark, Snackbar.LENGTH_LONG).show()
+                } else {
+                    val uri = Uri.parse("package:" + this.packageName)
+                    startForResult.launch(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, uri))
+                }
+            } else {
+                AlarmUtil.setSessionAlarm(mActivity, session)
+                Snackbar.make(view, R.string.add_bookmark, Snackbar.LENGTH_LONG).show()
+            }
         }
         PreferenceUtil.saveStarredIds(this, sessionIds)
     }

--- a/app/src/main/java/app/opass/ccip/util/AlarmUtil.kt
+++ b/app/src/main/java/app/opass/ccip/util/AlarmUtil.kt
@@ -1,12 +1,15 @@
 package app.opass.ccip.util
 
+import android.app.Activity
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
-import android.provider.Settings
+import android.util.Log
+import android.widget.Toast
+import androidx.core.app.AlarmManagerCompat
+import app.opass.ccip.R
 import app.opass.ccip.model.Session
 import app.opass.ccip.ui.sessiondetail.SessionDetailActivity
 import com.google.gson.internal.bind.util.ISO8601Utils
@@ -15,7 +18,27 @@ import java.text.ParsePosition
 import java.util.*
 
 object AlarmUtil {
+
+    private const val TAG = "AlarmUtil"
+
     fun setSessionAlarm(context: Context, session: Session) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            if (!alarmManager.canScheduleExactAlarms()) {
+                // We don't have the permission, exit!
+                Log.i(TAG, "Missing SCHEDULE_EXACT_ALARM permission!")
+                if (context is Activity) {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.alarm_perm_denied),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                return
+            }
+        }
+
+        // Try to schedule the Alarm assuming we have required permissions
         try {
             val date = ISO8601Utils.parse(session.start, ParsePosition(0))
             val calendar = Calendar.getInstance()
@@ -29,39 +52,18 @@ object AlarmUtil {
                 .getBroadcast(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
 
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-
-
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                alarmManager.setExact(
-                    AlarmManager.RTC_WAKEUP,
-                    calendar.timeInMillis - 10 * 60 * 1000,
-                    pendingIntent
-                )
-            }
-            else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                when {
-                    alarmManager.canScheduleExactAlarms() -> {
-                        alarmManager.setExactAndAllowWhileIdle(
-                            AlarmManager.RTC_WAKEUP,
-                            calendar.timeInMillis - 10 * 60 * 1000,
-                            pendingIntent
-                        )
-                    }
-                    else -> {
-                        var uri = Uri.parse("package:" + context.packageName)
-                        context.startActivity(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, uri))
-                    }
-                }
-            }
-            else {
-                alarmManager.setExactAndAllowWhileIdle(
-                    AlarmManager.RTC_WAKEUP,
-                    calendar.timeInMillis - 10 * 60 * 1000,
-                    pendingIntent
-                )
-            }
+            AlarmManagerCompat.setExactAndAllowWhileIdle(
+                alarmManager,
+                AlarmManager.RTC_WAKEUP,
+                calendar.timeInMillis - 10 * 60 * 1000,
+                pendingIntent
+            )
         } catch (e: ParseException) {
             e.printStackTrace()
+        } finally {
+            // Mark the session as starred regardless of Alarm status
+            val sessionIds = PreferenceUtil.loadStarredIds(context).toMutableList()
+            sessionIds.add(session.id)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,5 @@
     <string name="is_about_to_start">%s is about to start!</string>
     <string name="my_favorite_session_this_year_is">My favorite this year is</string>
     <string name="use_opass_to_make_your_own_agenda_together">Use OPass to make your own agenda together!</string>
+    <string name="alarm_perm_denied">Required permission denied! Please grant permission to schedule event.</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR is supposed to fix #73. We do this by checking if we can` scheduleExactAlarm` or not and then request permission. Scheduling is done using compact API to avoid extra burden.

## Testing

Open the app and try to schedule reminders for an event. Notice on Android 14 it asks for permission while on earlier versions it schedules without any issues.