### PR TITLE
Request notification and alarm permission

### DIFF
--- a/app/src/main/java/app/opass/ccip/ui/dialogs/NotificationDialogFragment.kt
+++ b/app/src/main/java/app/opass/ccip/ui/dialogs/NotificationDialogFragment.kt
@@ -2,8 +2,10 @@ package app.opass.ccip.ui.dialogs
 
 import android.app.Dialog
 import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import app.opass.ccip.R
+import app.opass.ccip.util.PreferenceUtil
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class NotificationDialogFragment (private val callback: () -> Unit) : DialogFragment() {
@@ -19,7 +21,11 @@ class NotificationDialogFragment (private val callback: () -> Unit) : DialogFrag
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 callback()
             }
-            .setNegativeButton(android.R.string.cancel)  { _, _ ->
+            .setNeutralButton(getString(R.string.later))  { _, _ ->
+                dismiss()
+            }
+            .setNegativeButton(getString(R.string.dont_ask_again))  { _, _ ->
+                PreferenceUtil.shouldPromptForNotification(requireContext(), false)
                 dismiss()
             }
             .create()

--- a/app/src/main/java/app/opass/ccip/ui/dialogs/NotificationDialogFragment.kt
+++ b/app/src/main/java/app/opass/ccip/ui/dialogs/NotificationDialogFragment.kt
@@ -1,0 +1,27 @@
+package app.opass.ccip.ui.dialogs
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import app.opass.ccip.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+class NotificationDialogFragment (private val callback: () -> Unit) : DialogFragment() {
+
+    companion object {
+        const val TAG = "NotificationDialogFragment"
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(getString(R.string.get_notified_title))
+            .setMessage(getString(R.string.get_notified_desc))
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                callback()
+            }
+            .setNegativeButton(android.R.string.cancel)  { _, _ ->
+                dismiss()
+            }
+            .create()
+    }
+}

--- a/app/src/main/java/app/opass/ccip/ui/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/app/opass/ccip/ui/schedule/ScheduleFragment.kt
@@ -1,12 +1,18 @@
 package app.opass.ccip.ui.schedule
 
 import android.app.Activity
+import android.app.AlarmManager
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -25,6 +31,12 @@ import app.opass.ccip.util.AlarmUtil
 import app.opass.ccip.util.PreferenceUtil
 
 class ScheduleFragment : Fragment() {
+
+    private val startForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ ->
+            context?.let { AlarmUtil.setSessionAlarm(it, session) }
+        }
+
     companion object {
         private const val ARG_DATE = "ARG_DATE"
 
@@ -42,6 +54,7 @@ class ScheduleFragment : Fragment() {
     private lateinit var mActivity: Activity
     private lateinit var vm: ScheduleViewModel
     private lateinit var scheduleView: RecyclerView
+    private lateinit var session: Session
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -103,17 +116,27 @@ class ScheduleFragment : Fragment() {
     }
 
     private fun onToggleStarState(session: Session): Boolean {
+        this.session = session
         val sessionIds = PreferenceUtil.loadStarredIds(mActivity).toMutableList()
         val isAlreadyStarred = sessionIds.contains(session.id)
         if (isAlreadyStarred) {
             sessionIds.remove(session.id)
+            PreferenceUtil.saveStarredIds(mActivity, sessionIds)
             AlarmUtil.cancelSessionAlarm(mActivity, session)
         } else {
-            sessionIds.add(session.id)
-            AlarmUtil.setSessionAlarm(mActivity, session)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val alarmManager = context?.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                if (alarmManager.canScheduleExactAlarms()) {
+                    AlarmUtil.setSessionAlarm(mActivity, session)
+                } else {
+                    val uri = Uri.parse("package:" + requireContext().packageName)
+                    startForResult.launch(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, uri))
+                }
+            } else {
+                AlarmUtil.setSessionAlarm(mActivity, session)
+            }
         }
         vm.hasStarredSessions.value = sessionIds.isNotEmpty()
-        PreferenceUtil.saveStarredIds(mActivity, sessionIds)
         return !isAlreadyStarred
     }
 

--- a/app/src/main/java/app/opass/ccip/ui/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/app/opass/ccip/ui/schedule/ScheduleFragment.kt
@@ -143,10 +143,13 @@ class ScheduleFragment : Fragment() {
         } else {
             sessionIds.add(session.id)
 
-            val notificationManager = context?.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            if (!notificationManager.areNotificationsEnabled()) {
-                NotificationDialogFragment(::requestNotificationPermission)
-                    .show(childFragmentManager, NotificationDialogFragment.TAG)
+            if (PreferenceUtil.shouldPromptForNotification(requireContext())) {
+                val notificationManager =
+                    context?.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                if (!notificationManager.areNotificationsEnabled()) {
+                    NotificationDialogFragment(::requestNotificationPermission)
+                        .show(childFragmentManager, NotificationDialogFragment.TAG)
+                }
             }
         }
         vm.hasStarredSessions.value = sessionIds.isNotEmpty()

--- a/app/src/main/java/app/opass/ccip/ui/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/app/opass/ccip/ui/schedule/ScheduleFragment.kt
@@ -51,7 +51,7 @@ class ScheduleFragment : Fragment() {
                 scheduleAlarm()
             } else {
                 Log.i(TAG, "Missing notification permission!")
-                Toast.makeText(context, getString(R.string.perm_denied), Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, getString(R.string.perm_denied), Toast.LENGTH_LONG).show()
             }
         }
 

--- a/app/src/main/java/app/opass/ccip/ui/sessiondetail/SessionDetailActivity.kt
+++ b/app/src/main/java/app/opass/ccip/ui/sessiondetail/SessionDetailActivity.kt
@@ -231,10 +231,13 @@ class SessionDetailActivity : AppCompatActivity() {
         } else {
             sessionIds.add(session.id)
 
-            val notificationManager = this.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            if (!notificationManager.areNotificationsEnabled()) {
-                NotificationDialogFragment (::requestNotificationPermission)
-                    .show(supportFragmentManager, NotificationDialogFragment.TAG)
+            if (PreferenceUtil.shouldPromptForNotification(this)) {
+                val notificationManager =
+                    this.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                if (!notificationManager.areNotificationsEnabled()) {
+                    NotificationDialogFragment (::requestNotificationPermission)
+                        .show(supportFragmentManager, NotificationDialogFragment.TAG)
+                }
             }
         }
         PreferenceUtil.saveStarredIds(this, sessionIds)

--- a/app/src/main/java/app/opass/ccip/ui/sessiondetail/SessionDetailActivity.kt
+++ b/app/src/main/java/app/opass/ccip/ui/sessiondetail/SessionDetailActivity.kt
@@ -57,7 +57,7 @@ class SessionDetailActivity : AppCompatActivity() {
                 scheduleAlarm()
             } else {
                 Log.i(TAG, "Missing notification permission!")
-                Toast.makeText(this, getString(R.string.perm_denied), Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, getString(R.string.perm_denied), Toast.LENGTH_LONG).show()
             }
         }
 

--- a/app/src/main/java/app/opass/ccip/util/AlarmUtil.kt
+++ b/app/src/main/java/app/opass/ccip/util/AlarmUtil.kt
@@ -1,12 +1,15 @@
 package app.opass.ccip.util
 
+import android.app.Activity
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
-import android.provider.Settings
+import android.util.Log
+import android.widget.Toast
+import androidx.core.app.AlarmManagerCompat
+import app.opass.ccip.R
 import app.opass.ccip.model.Session
 import app.opass.ccip.ui.sessiondetail.SessionDetailActivity
 import com.google.gson.internal.bind.util.ISO8601Utils
@@ -15,7 +18,27 @@ import java.text.ParsePosition
 import java.util.*
 
 object AlarmUtil {
+
+    private const val TAG = "AlarmUtil"
+
     fun setSessionAlarm(context: Context, session: Session) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            if (!alarmManager.canScheduleExactAlarms()) {
+                // We don't have the permission, exit!
+                Log.i(TAG, "Missing SCHEDULE_EXACT_ALARM permission!")
+                if (context is Activity) {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.alarm_perm_denied),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                return
+            }
+        }
+
+        // Try to schedule the Alarm assuming we have required permissions
         try {
             val date = ISO8601Utils.parse(session.start, ParsePosition(0))
             val calendar = Calendar.getInstance()
@@ -29,39 +52,19 @@ object AlarmUtil {
                 .getBroadcast(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
 
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-
-
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                alarmManager.setExact(
-                    AlarmManager.RTC_WAKEUP,
-                    calendar.timeInMillis - 10 * 60 * 1000,
-                    pendingIntent
-                )
-            }
-            else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                when {
-                    alarmManager.canScheduleExactAlarms() -> {
-                        alarmManager.setExactAndAllowWhileIdle(
-                            AlarmManager.RTC_WAKEUP,
-                            calendar.timeInMillis - 10 * 60 * 1000,
-                            pendingIntent
-                        )
-                    }
-                    else -> {
-                        var uri = Uri.parse("package:" + context.packageName)
-                        context.startActivity(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, uri))
-                    }
-                }
-            }
-            else {
-                alarmManager.setExactAndAllowWhileIdle(
-                    AlarmManager.RTC_WAKEUP,
-                    calendar.timeInMillis - 10 * 60 * 1000,
-                    pendingIntent
-                )
-            }
+            AlarmManagerCompat.setExactAndAllowWhileIdle(
+                alarmManager,
+                AlarmManager.RTC_WAKEUP,
+                calendar.timeInMillis - 10 * 60 * 1000,
+                pendingIntent
+            )
         } catch (e: ParseException) {
             e.printStackTrace()
+        } finally {
+            // Mark the session as starred regardless of Alarm status
+            val sessionIds = PreferenceUtil.loadStarredIds(context).toMutableList()
+            sessionIds.add(session.id)
+            PreferenceUtil.saveStarredIds(context, sessionIds)
         }
     }
 

--- a/app/src/main/java/app/opass/ccip/util/AlarmUtil.kt
+++ b/app/src/main/java/app/opass/ccip/util/AlarmUtil.kt
@@ -30,7 +30,7 @@ object AlarmUtil {
                 if (context is Activity) {
                     Toast.makeText(
                         context,
-                        context.getString(R.string.alarm_perm_denied),
+                        context.getString(R.string.perm_denied),
                         Toast.LENGTH_SHORT
                     ).show()
                 }
@@ -58,13 +58,8 @@ object AlarmUtil {
                 calendar.timeInMillis - 10 * 60 * 1000,
                 pendingIntent
             )
-        } catch (e: ParseException) {
-            e.printStackTrace()
-        } finally {
-            // Mark the session as starred regardless of Alarm status
-            val sessionIds = PreferenceUtil.loadStarredIds(context).toMutableList()
-            sessionIds.add(session.id)
-            PreferenceUtil.saveStarredIds(context, sessionIds)
+        } catch (exception: Exception) {
+            Log.e(TAG, "Failed to schedule event!", exception)
         }
     }
 

--- a/app/src/main/java/app/opass/ccip/util/AlarmUtil.kt
+++ b/app/src/main/java/app/opass/ccip/util/AlarmUtil.kt
@@ -31,7 +31,7 @@ object AlarmUtil {
                     Toast.makeText(
                         context,
                         context.getString(R.string.perm_denied),
-                        Toast.LENGTH_SHORT
+                        Toast.LENGTH_LONG
                     ).show()
                 }
                 return

--- a/app/src/main/java/app/opass/ccip/util/PreferenceUtil.kt
+++ b/app/src/main/java/app/opass/ccip/util/PreferenceUtil.kt
@@ -17,6 +17,9 @@ object PreferenceUtil {
     private const val PREF_SCHEDULE_SCHEDULE = "schedule"
     private const val PREF_SCHEDULE_STARS = "stars"
 
+    private const val DEFAULT_SHARED_PREFS = "default_shared_prefs"
+    private const val NOTIFICATION = "notification"
+
     fun setCurrentEvent(context: Context, eventConfig: EventConfig) {
         context.getSharedPreferences(PREF_EVENT, Context.MODE_PRIVATE)
             .edit(true) { putString(PREF_CURRENT_EVENT, JsonUtil.toJson(eventConfig)) }
@@ -88,5 +91,17 @@ object PreferenceUtil {
         } catch (t: Throwable) {
             emptyList<String>().also { saveStarredIds(context, it) }
         }
+    }
+
+    fun shouldPromptForNotification(context: Context): Boolean {
+        val sharedPreferences =
+            context.getSharedPreferences(DEFAULT_SHARED_PREFS, Context.MODE_PRIVATE)
+        return sharedPreferences.getBoolean(NOTIFICATION, true)
+    }
+
+    fun shouldPromptForNotification(context: Context, bool: Boolean) {
+        val sharedPreferences =
+            context.getSharedPreferences(DEFAULT_SHARED_PREFS, Context.MODE_PRIVATE)
+        sharedPreferences.edit { putBoolean(NOTIFICATION, bool) }
     }
 }

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -124,4 +124,9 @@
     <string name="is_about_to_start">%s 即將要開始囉！</string>
     <string name="my_favorite_session_this_year_is">今年我最感興趣的議程是</string>
     <string name="use_opass_to_make_your_own_agenda_together">一起使用 OPass 製作屬於你自己的議程表吧！</string>
+    <string name="perm_denied">沒有提供所需要的權限！請提供通知權限來獲取活動提醒</string>
+    <string name="get_notified_title">收到通知</string>
+    <string name="get_notified_desc">OPass 可以在此活動開始之前向您發送通知。 您想要允許 Opass 所需的權限嗎？</string>
+    <string name="dont_ask_again">不再詢問</string>
+    <string name="later">稍後</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,5 +124,7 @@
     <string name="is_about_to_start">%s is about to start!</string>
     <string name="my_favorite_session_this_year_is">My favorite this year is</string>
     <string name="use_opass_to_make_your_own_agenda_together">Use OPass to make your own agenda together!</string>
-    <string name="alarm_perm_denied">Required permission denied! Please grant permission to schedule event.</string>
+    <string name="perm_denied">Required permission denied! Please grant permission manually to get notification for event.</string>
+    <string name="get_notified_title">Get notified</string>
+    <string name="get_notified_desc">OPass can send you notification reminder before this event starts. Would you like to be notified?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,5 @@
     <string name="is_about_to_start">%s is about to start!</string>
     <string name="my_favorite_session_this_year_is">My favorite this year is</string>
     <string name="use_opass_to_make_your_own_agenda_together">Use OPass to make your own agenda together!</string>
+    <string name="alarm_perm_denied">Required permission denied! Please grant permission to schedule event.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,10 @@
     <string name="my_favorite_session_this_year_is">My favorite this year is</string>
     <string name="use_opass_to_make_your_own_agenda_together">Use OPass to make your own agenda together!</string>
     <string name="perm_denied">Required permission denied! Please grant permission manually to get notification for event.</string>
+
+    <!-- DialogFragment -->
     <string name="get_notified_title">Get notified</string>
-    <string name="get_notified_desc">OPass can send you notification reminder before this event starts. Would you like to be notified?</string>
+    <string name="get_notified_desc">OPass can send you notification just before this event starts. Would you like to allow Opass required permissions?</string>
+    <string name="dont_ask_again">Don\'t ask again</string>
+    <string name="later">Later</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR aims to make the following changes:

- Use ActivityResultContracts for requesting `POST_NOTIFICATION` and `ACTION_REQUEST_SCHEDULE_EXACT_ALARM` alarm that handles the result of the request
- Always allows adding a bookmark for the event but makes notification/alarm optional by showing a dialog before

## Testing

Ensure both notification and alarm permission are requested before scheduling an event. This should close #77. 