### PR TITLE
Use absolute import for activity_session_detail

### DIFF
--- a/app/src/main/res/layout/activity_session_detail.xml
+++ b/app/src/main/res/layout/activity_session_detail.xml
@@ -12,7 +12,7 @@
         android:layout_height="@dimen/app_bar_height"
         android:fitsSystemWindows="true"
         android:theme="@style/AppTheme.AppBarOverlay"
-        app:layout_behavior=".ui.sessiondetail.ScrollingControlAppBarLayoutBehavior">
+        app:layout_behavior="app.opass.ccip.ui.sessiondetail.ScrollingControlAppBarLayoutBehavior">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/toolbar_layout"


### PR DESCRIPTION
This is to prevent class name resolution failed when debugging using different application ID.

Change-Id: Ib752b9f875e4062732787036230fdd590ea5e953